### PR TITLE
Publisher can delete articles

### DIFF
--- a/app/controllers/api/v1/admin/articles_controller.rb
+++ b/app/controllers/api/v1/admin/articles_controller.rb
@@ -27,10 +27,14 @@ class Api::V1::Admin::ArticlesController < ApplicationController
   end
 
   def index
-    articles = Article.where(published: false)
+    articles = Article.where(published: params[:published])
     authorize(articles)
 
-    render json: articles, each_serializer: Articles::IndexSerializer, role: current_user.role
+    if articles.present?
+      render json: articles, each_serializer: Articles::IndexSerializer, role: current_user.role
+    else
+      render json: { error: "Missing parameters." }, status: 400
+    end
   end
 
   private

--- a/app/controllers/api/v1/admin/articles_controller.rb
+++ b/app/controllers/api/v1/admin/articles_controller.rb
@@ -37,6 +37,12 @@ class Api::V1::Admin::ArticlesController < ApplicationController
     end
   end
 
+  def show
+    article = Article.find(params[:id])
+    authorize(article)
+    render json: article, serializer: Articles::ShowSerializer
+  end
+
   def destroy
     article = Article.find(params[:id])
     authorize(article)

--- a/app/controllers/api/v1/admin/articles_controller.rb
+++ b/app/controllers/api/v1/admin/articles_controller.rb
@@ -29,12 +29,7 @@ class Api::V1::Admin::ArticlesController < ApplicationController
   def index
     articles = Article.where(published: params[:published])
     authorize(articles)
-
-    if articles.present?
-      render json: articles, each_serializer: Articles::IndexSerializer, role: current_user.role
-    else
-      render json: { error: "Missing parameters." }, status: 400
-    end
+    render json: articles, each_serializer: Articles::IndexSerializer, role: current_user.role
   end
 
   def show

--- a/app/controllers/api/v1/admin/articles_controller.rb
+++ b/app/controllers/api/v1/admin/articles_controller.rb
@@ -37,6 +37,18 @@ class Api::V1::Admin::ArticlesController < ApplicationController
     end
   end
 
+  def destroy
+    article = Article.find(params[:id])
+    authorize(article)
+    article.destroy
+
+    if article.destroyed?
+      render json: { message: "Article has been deleted" }, status: 200
+    else
+      render json: { error: article.errors.full_messages }, status: 422
+    end
+  end
+
   private
 
   def article_params

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -20,4 +20,8 @@ class ArticlePolicy < ApplicationPolicy
   def destroy?
     @user.publisher?
   end
+
+  def show?
+    @user.publisher?
+  end
 end

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -16,4 +16,8 @@ class ArticlePolicy < ApplicationPolicy
   def update?
     @user.publisher?
   end
+
+  def destroy?
+    @user.publisher?
+  end
 end

--- a/app/serializers/articles/index_serializer.rb
+++ b/app/serializers/articles/index_serializer.rb
@@ -2,7 +2,7 @@ class Articles::IndexSerializer < ActiveModel::Serializer
   include ActionView::Helpers::TextHelper
   include Rails.application.routes.url_helpers
 
-  attributes :id, :title, :body, :image, :category, :location
+  attributes :id, :title, :body, :image, :category, :location, :journalist
 
   def body
     if instance_options[:role] == 'publisher'
@@ -22,5 +22,9 @@ class Articles::IndexSerializer < ActiveModel::Serializer
         object.image.service_url(expires_in: 1.hours, disposition: 'inline')
       end
     end
+  end
+
+  def journalist
+    object.journalist.uid
   end
 end

--- a/app/serializers/articles/show_serializer.rb
+++ b/app/serializers/articles/show_serializer.rb
@@ -2,7 +2,7 @@ class Articles::ShowSerializer < ActiveModel::Serializer
   include ActionView::Helpers::TextHelper
   include Rails.application.routes.url_helpers
 
-  attributes :id, :title, :body, :image, :category, :location
+  attributes :id, :title, :body, :image, :category, :location, :journalist
 
   def body
     if !current_user.nil? && !current_user.role.nil?
@@ -22,5 +22,9 @@ class Articles::ShowSerializer < ActiveModel::Serializer
         object.image.service_url(expires_in: 1.hours, disposition: 'inline')
       end
     end
+  end
+
+  def journalist
+    object.journalist.uid
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :articles, only: [:show, :index]
       resources :subscriptions, only: [:create]
       namespace :admin, defaults: { format: :json } do
-        resources :articles, only: [:create, :update, :index, :destroy]
+        resources :articles, only: [:create, :update, :index, :show, :destroy]
         resources :users, only: [:show]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :articles, only: [:show, :index]
       resources :subscriptions, only: [:create]
       namespace :admin, defaults: { format: :json } do
-        resources :articles, only: [:create, :update, :index]
+        resources :articles, only: [:create, :update, :index, :destroy]
         resources :users, only: [:show]
       end
     end

--- a/spec/requests/api/v1/admin/articles/delete_spec.rb
+++ b/spec/requests/api/v1/admin/articles/delete_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe 'GET/api/admin/articles', type: :request do
+  let(:publisher)  { create(:publisher)}
+  let(:publisher_credentials) { publisher.create_new_auth_token }
+  let!(:publisher_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(publisher_credentials) }
+  let!(:article) { create(:article) }
+
+
+  describe 'Successfully lists unpublished articles' do
+    before do
+      delete "/api/v1/admin/articles/#{article.id}",
+      headers: publisher_headers
+    end
+    
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns success message' do
+      expect(response_json['message'].count).to eq "Article has been deleted"
+    end
+
+    it 'returns the article writer' do
+      get "/api/v1/articles/#{article.id}",
+      binding.pry
+      expect(response_json['errors']).to eq "Article not found"
+    end
+  end
+
+  describe 'unsuccessfully when' do
+    describe 'logged in as a journalist' do
+      let(:journalist) { create(:user, role: 'journalist')}
+      let(:journalist_credentials) { journalist.create_new_auth_token }
+      let!(:journalist_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(journalist_credentials) }
+      
+      before do
+        delete "/api/v1/admin/articles/#{article.id}",
+        headers: journalist_credentials
+      end
+
+      it 'returns a 404 response status' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns error message' do
+        expect(response_json["error"]).to eq "Not authorized!"
+      end
+    end
+
+    describe 'not logged in' do
+      let!(:non_authorized_headers) { { HTTP_ACCEPT: 'application/json' } }
+      before do
+        get "/api/v1/admin/articles",
+        headers: non_authorized_headers
+      end
+      
+      it 'returns a 401 response status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'returns error message' do
+        expect(response_json["errors"][0]).to eq "You need to sign in or sign up before continuing."
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/articles/delete_spec.rb
+++ b/spec/requests/api/v1/admin/articles/delete_spec.rb
@@ -1,11 +1,11 @@
-RSpec.describe 'GET/api/admin/articles', type: :request do
+RSpec.describe 'DELETE /api/admin/articles', type: :request do
   let(:publisher)  { create(:publisher)}
   let(:publisher_credentials) { publisher.create_new_auth_token }
   let!(:publisher_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(publisher_credentials) }
   let!(:article) { create(:article) }
 
 
-  describe 'Successfully lists unpublished articles' do
+  describe 'Successfully deletes article' do
     before do
       delete "/api/v1/admin/articles/#{article.id}",
       headers: publisher_headers
@@ -16,13 +16,14 @@ RSpec.describe 'GET/api/admin/articles', type: :request do
     end
 
     it 'returns success message' do
-      expect(response_json['message'].count).to eq "Article has been deleted"
+      expect(response_json['message']).to eq "Article has been deleted"
     end
 
-    it 'returns the article writer' do
+    it 'returns no article' do
       get "/api/v1/articles/#{article.id}",
-      binding.pry
-      expect(response_json['errors']).to eq "Article not found"
+      headers: { HTTP_ACCEPT: 'application/json' }
+
+      expect(response_json['error']).to eq 'Article not found'
     end
   end
 

--- a/spec/requests/api/v1/admin/articles/index_spec.rb
+++ b/spec/requests/api/v1/admin/articles/index_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'GET/api/admin/articles', type: :request do
   describe 'Successfully lists unpublished articles' do
     before do
       get '/api/v1/admin/articles',
-      headers:publisher_headers
+      params: { published: false },
+      headers: publisher_headers
     end
     
     it 'returns a 200 response status' do
@@ -22,6 +23,26 @@ RSpec.describe 'GET/api/admin/articles', type: :request do
 
     it 'returns 3 articles' do
       expect(response_json['articles'].count).to eq 3
+    end
+
+    it 'returns the article writer' do
+      expect(response_json['articles'].first['journalist']).to include "user"
+    end
+  end
+
+  describe 'Successfully lists published articles' do
+    before do
+      get '/api/v1/admin/articles',
+      params: { published: true },
+      headers: publisher_headers
+    end
+    
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns 1 article' do
+      expect(response_json['articles'].count).to eq 1
     end
   end
 
@@ -58,6 +79,21 @@ RSpec.describe 'GET/api/admin/articles', type: :request do
 
       it 'returns error message' do
         expect(response_json["errors"][0]).to eq "You need to sign in or sign up before continuing."
+      end
+    end
+
+    describe 'no params' do
+      before do
+        get '/api/v1/admin/articles',
+        headers: publisher_headers
+      end
+      
+      it 'returns a 400 response status' do
+        expect(response).to have_http_status 400
+      end
+
+      it 'returns error message' do
+        expect(response_json["error"]).to eq "Missing parameters."
       end
     end
   end

--- a/spec/requests/api/v1/admin/articles/index_spec.rb
+++ b/spec/requests/api/v1/admin/articles/index_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe 'GET/api/admin/articles', type: :request do
     end
   end
 
+  describe 'no articles without params' do
+    before do
+      get '/api/v1/admin/articles',
+      headers: publisher_headers
+    end
+    
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns 0 articles' do
+      expect(response_json['articles'].count).to eq 0
+    end
+  end
+
   describe 'unsuccessfully when' do
     describe 'logged in as a journalist' do
       let(:journalist) { create(:user, role: 'journalist')}
@@ -79,21 +94,6 @@ RSpec.describe 'GET/api/admin/articles', type: :request do
 
       it 'returns error message' do
         expect(response_json["errors"][0]).to eq "You need to sign in or sign up before continuing."
-      end
-    end
-
-    describe 'no params' do
-      before do
-        get '/api/v1/admin/articles',
-        headers: publisher_headers
-      end
-      
-      it 'returns a 400 response status' do
-        expect(response).to have_http_status 400
-      end
-
-      it 'returns error message' do
-        expect(response_json["error"]).to eq "Missing parameters."
       end
     end
   end

--- a/spec/requests/api/v1/admin/articles/show_spec.rb
+++ b/spec/requests/api/v1/admin/articles/show_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/v1/admin/articles/:id', type: :request do
+  let(:publisher)  { create(:publisher)}
+  let(:publisher_credentials) { publisher.create_new_auth_token }
+  let!(:publisher_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(publisher_credentials) }
+  let!(:article) { create(:article)}
+  let!(:published_article) {create(:article, published: true, publisher: publisher)}
+
+  describe 'Successfully' do
+    describe 'retrieves unpublished article' do
+      before do
+        get "/api/v1/admin/articles/#{article.id}", headers: publisher_headers
+      end
+
+      it 'returns a 200 response status' do
+        expect(response).to have_http_status 200
+      end
+
+      it 'returns full article body' do
+        expect(response_json['article']['body'].length).to eq article.body.length
+      end
+    end
+
+    describe 'retrieves published article' do
+      before do
+        get "/api/v1/admin/articles/#{published_article.id}", headers: publisher_headers
+      end
+
+      it 'returns full article body' do
+        expect(response_json['article']['body'].length).to eq article.body.length
+      end
+    end
+  end
+
+  describe 'With invalid :id' do
+    before do
+      get '/api/v1/articles/10000', headers: headers
+    end
+
+    it 'returns error if article does not exist' do
+      expect(response_json['error']).to eq 'Article not found'
+    end
+  end
+end

--- a/spec/serializers/articles/index_serializer_spec.rb
+++ b/spec/serializers/articles/index_serializer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Articles::IndexSerializer, type: :serializer do
   let(:serialization) { Articles::IndexSerializer.new(article) }
   subject { JSON.parse(serialization.to_json) }
 
-  it 'contains id, title, body, image, category and location' do
+  it 'contains id, title, body, image, journalist, category and location' do
     expected_keys = ['id', 'title', 'body', 'image', 'category', 'location', 'journalist']
     expect(subject.keys).to match expected_keys
   end

--- a/spec/serializers/articles/index_serializer_spec.rb
+++ b/spec/serializers/articles/index_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Articles::IndexSerializer, type: :serializer do
   subject { JSON.parse(serialization.to_json) }
 
   it 'contains id, title, body, image, category and location' do
-    expected_keys = ['id', 'title', 'body', 'image', 'category', 'location']
+    expected_keys = ['id', 'title', 'body', 'image', 'category', 'location', 'journalist']
     expect(subject.keys).to match expected_keys
   end
 

--- a/spec/serializers/articles/show_serializer_spec.rb
+++ b/spec/serializers/articles/show_serializer_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Articles::ShowSerializer, type: :serializer do
     .new(article, scope: create(:user), scope_name: :current_user)}
   subject { JSON.parse(serialization.to_json) }
 
-  it 'contains id, title, body, image, category and location' do
-    expected_keys = ['id', 'title', 'body', 'image', 'category', 'location']
+  it 'contains id, title, body, image, journalist, category and location' do
+    expected_keys = ['id', 'title', 'body', 'image', 'category', 'location', 'journalist']
     expect(subject.keys).to match expected_keys
   end
 end


### PR DESCRIPTION
[PT link](https://www.pivotaltracker.com/story/show/170674626)

Adds delete action for role publisher
Lets publisher list both published and unpublished articles (with param `published: true || false`)
Lets publisher show both published and unpublished articles
Adds journalist to article response for both ArticlesController and Admin::ArticlesController